### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides Angular CLI and workspace automation capabilities. This server enables LLMs and agents to interact with Angular projects, generate components/services, add packages, create new workspaces, and run custom architect targets via the Angular CLI.
 
+<a href="https://glama.ai/mcp/servers/@talzach/mcp-angular-cli">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@talzach/mcp-angular-cli/badge" alt="mcp-angular-cli MCP server" />
+</a>
+
 ## Features
 
 - Run `ng generate` to scaffold Angular artifacts (components, services, etc.)


### PR DESCRIPTION
This PR adds a badge for the [mcp-angular-cli](https://glama.ai/mcp/servers/@talzach/mcp-angular-cli) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@talzach/mcp-angular-cli">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@talzach/mcp-angular-cli/badge" alt="mcp-angular-cli MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.